### PR TITLE
Fix port and force docker-compose to run on linux/amd64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .env.prod
 .idea
 *.iml
+*.snapshot
+*.tgz

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ docker-compose --profile local up -d
 ### Loading the data
 
 At this point, you should have a running demo. However, it does not contain any data,
-but the web application is already available at http://localhost:8080. You can open it
+but the web application is already available at http://localhost:8001. You can open it
 in your browser.
 
 ![Empty demo](images/empty-demo.png)
@@ -177,7 +177,7 @@ curl -X PUT \
 ### Using the application
 
 Once your demo is up and running, you can open it in your browser at 
-http://localhost:8080 and finally start using it.
+http://localhost:8001 and finally start using it.
 
 ![Working demo](images/working-demo.png)
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,12 @@
 services:
 
   backend:
+    platform: linux/amd64
     build: .
     env_file: .env
     restart: always
     ports:
-      - "8000:8000"
+      - "8001:8001"
     volumes:
       - models_cache:/app/models_cache
 


### PR DESCRIPTION
The latter is necessary so that it works on a Apple Silicon Mac since there is a Python dependency which is not built for arm.